### PR TITLE
4주차 과제

### DIFF
--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentProcessor.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentProcessor.kt
@@ -9,8 +9,6 @@ import com.loopers.domain.payment.PaymentService
 import com.loopers.domain.payment.dto.command.PaymentCommand
 import com.loopers.domain.payment.entity.Payment
 import com.loopers.domain.point.PointService
-import com.loopers.domain.product.ProductOptionService
-import com.loopers.domain.product.ProductService
 import com.loopers.domain.product.ProductStockService
 import com.loopers.domain.product.dto.command.ProductStockCommand
 import com.loopers.domain.product.dto.result.ProductStockResult
@@ -25,8 +23,6 @@ class PaymentProcessor(
     private val paymentService: PaymentService,
     private val orderService: OrderService,
     private val orderItemService: OrderItemService,
-    private val productService: ProductService,
-    private val productOptionService: ProductOptionService,
     private val productStockService: ProductStockService,
     private val pointService: PointService,
     private val paymentStateService: PaymentStateService,

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/like/LikeCountRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/like/LikeCountRepository.kt
@@ -6,6 +6,8 @@ import com.loopers.domain.like.vo.LikeTarget.Type
 interface LikeCountRepository {
     fun findCountByTargetIdAndType(targetId: Long, type: Type): LikeCount?
 
+    fun findCountWithLockByTargetIdAndType(targetId: Long, type: Type): LikeCount?
+
     fun findAllCountByTargetIdAndType(targetIds: List<Long>, type: Type): List<LikeCount>
 
     fun save(likeCount: LikeCount): LikeCount

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/like/LikeCountService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/like/LikeCountService.kt
@@ -16,6 +16,11 @@ class LikeCountService(
             ?: throw CoreException(ErrorType.NOT_FOUND, "[targetId = $targetId, targetType = $type] 좋아요 수를 찾을 수 없습니다.")
     }
 
+    fun getLikeCountWithLock(targetId: Long, type: Type): LikeCount {
+        return likeCountRepository.findCountWithLockByTargetIdAndType(targetId, type)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "[targetId = $targetId, targetType = $type] 좋아요 수를 찾을 수 없습니다.")
+    }
+
     fun getLikeCounts(targetIds: List<Long>, type: Type): List<LikeCount> {
         return likeCountRepository.findAllCountByTargetIdAndType(targetIds, type)
     }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/like/entity/LikeCount.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/like/entity/LikeCount.kt
@@ -31,6 +31,14 @@ class LikeCount protected constructor(
     var count: LikeCountValue = count
         protected set
 
+    fun increase() {
+        this.count = this.count.increase()
+    }
+
+    fun decrease() {
+        this.count = this.count.decrease()
+    }
+
     companion object {
         fun create(targetId: Long, type: Type, count: Long): LikeCount {
             return LikeCount(LikeTarget.create(type, targetId), LikeCountValue(count))

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/Point.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/Point.kt
@@ -7,6 +7,7 @@ import com.loopers.support.error.ErrorType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import jakarta.persistence.Version
 import java.math.BigDecimal
 
 @Entity
@@ -23,6 +24,10 @@ class Point protected constructor(
     @Column(name = "amount", nullable = false)
     var amount: Amount = amount
         protected set
+
+    @Version
+    @Column(name = "version", nullable = false)
+    var version: Long? = null
 
     companion object {
         fun create(userId: Long, amount: BigDecimal): Point {

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductStockRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductStockRepository.kt
@@ -7,5 +7,7 @@ interface ProductStockRepository {
 
     fun findAll(productOptionIds: List<Long>): List<ProductStock>
 
+    fun findAllWithLock(productOptionIds: List<Long>): List<ProductStock>
+
     fun save(productStock: ProductStock): ProductStock
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductStockService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductStockService.kt
@@ -12,7 +12,7 @@ class ProductStockService(
 ) {
     fun getDecreaseStock(command: ProductStockCommand.GetDecreaseStock): ProductStockResult.DecreaseStocks {
         val decreaseMap = command.decreaseStocks.associateBy { it.productOptionId }
-        val stocks = productStockRepository.findAll(decreaseMap.keys.toList())
+        val stocks = productStockRepository.findAllWithLock(decreaseMap.keys.toList())
 
         return ProductStockResult.DecreaseStocks(
             stocks.map { stock ->

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/like/LikeCountJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/like/LikeCountJpaRepository.kt
@@ -2,11 +2,18 @@ package com.loopers.infrastructure.like
 
 import com.loopers.domain.like.entity.LikeCount
 import com.loopers.domain.like.vo.LikeTarget.Type
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 
 interface LikeCountJpaRepository : JpaRepository<LikeCount, Long> {
     @Suppress("FunctionName")
     fun findByTarget_TargetIdAndTarget_Type(targetTargetId: Long, type: Type): LikeCount?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT lc FROM LikeCount lc WHERE lc.target.targetId = :targetTargetId AND lc.target.type = :type")
+    fun findCountWithLockByTargetIdAndType(targetTargetId: Long, type: Type): LikeCount?
 
     @Suppress("FunctionName")
     fun findAllByTarget_TargetIdInAndTarget_Type(targetTargetIds: List<Long>, type: Type): List<LikeCount>

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/like/LikeCountRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/like/LikeCountRepositoryImpl.kt
@@ -16,6 +16,13 @@ class LikeCountRepositoryImpl(
         return userCountJpaRepository.findByTarget_TargetIdAndTarget_Type(targetId, type)
     }
 
+    override fun findCountWithLockByTargetIdAndType(
+        targetId: Long,
+        type: Type,
+    ): LikeCount? {
+        return userCountJpaRepository.findCountWithLockByTargetIdAndType(targetId, type)
+    }
+
     override fun findAllCountByTargetIdAndType(
         targetIds: List<Long>,
         type: Type,

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductStockJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductStockJpaRepository.kt
@@ -1,6 +1,13 @@
 package com.loopers.infrastructure.product
 
 import com.loopers.domain.product.entity.ProductStock
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 
-interface ProductStockJpaRepository : JpaRepository<ProductStock, Long>
+interface ProductStockJpaRepository : JpaRepository<ProductStock, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ps FROM ProductStock ps WHERE ps.id in :productOptionIds")
+    fun findAllWithLock(productOptionIds: List<Long>): List<ProductStock>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductStockRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductStockRepositoryImpl.kt
@@ -17,6 +17,10 @@ class ProductStockRepositoryImpl(
         return productStockJpaRepository.findAllById(productOptionIds)
     }
 
+    override fun findAllWithLock(productOptionIds: List<Long>): List<ProductStock> {
+        return productStockJpaRepository.findAllWithLock(productOptionIds)
+    }
+
     override fun save(productStock: ProductStock): ProductStock {
         return productStockJpaRepository.save(productStock)
     }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/like/LikeFacadeIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/like/LikeFacadeIntegrationTest.kt
@@ -2,13 +2,13 @@ package com.loopers.application.like
 
 import com.loopers.application.product.ProductFacade
 import com.loopers.domain.brand.entity.Brand
+import com.loopers.domain.like.LikeCountRepository
+import com.loopers.domain.like.dto.command.LikeCommand
 import com.loopers.domain.like.dto.command.LikeCommand.AddLike
 import com.loopers.domain.like.dto.criteria.LikeCriteria
-import com.loopers.domain.like.vo.LikeTarget
 import com.loopers.domain.like.vo.LikeTarget.Type.PRODUCT
 import com.loopers.domain.product.dto.command.ProductCommand
 import com.loopers.infrastructure.brand.BrandJpaRepository
-import com.loopers.infrastructure.product.ProductJpaRepository
 import com.loopers.utils.DatabaseCleanUp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -18,13 +18,15 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import java.math.BigDecimal
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 
 @SpringBootTest
 class LikeFacadeIntegrationTest @Autowired constructor(
     private val productFacade: ProductFacade,
-    private val productRepository: ProductJpaRepository,
     private val brandRepository: BrandJpaRepository,
     private val likeFacade: LikeFacade,
+    private val likeCountRepository: LikeCountRepository,
     private val databaseCleanUp: DatabaseCleanUp,
 ) {
     @AfterEach
@@ -45,14 +47,90 @@ class LikeFacadeIntegrationTest @Autowired constructor(
             val productDetail2 = productFacade.registerProduct(ProductCommand.RegisterProduct(brand1.id, "name2", "description2", BigDecimal(3)))
             val productDetail3 = productFacade.registerProduct(ProductCommand.RegisterProduct(brand2.id, "name3", "description3", BigDecimal(2)))
 
-            likeFacade.addLike(AddLike(1, productDetail1.id, LikeTarget.Type.PRODUCT))
-            likeFacade.addLike(AddLike(1, productDetail2.id, LikeTarget.Type.PRODUCT))
+            likeFacade.addLike(AddLike(1, productDetail1.id, PRODUCT))
+            likeFacade.addLike(AddLike(1, productDetail2.id, PRODUCT))
 
             // when
             val likeDetails = likeFacade.getLikesForProduct(LikeCriteria.FindAll(userId = 1, type = PRODUCT))
 
             // then
             assertThat(true)
+        }
+    }
+
+    @DisplayName("동시성 테스트")
+    @Nested
+    inner class Concurrency {
+
+        @Test
+        fun `여러 유저가 동시에 같은 상품에 좋아요 요청을 보내도 좋아요 수는 정확히 반영되어야 한다`() {
+            // given
+            val userCount = 20
+            val brand = brandRepository.save(Brand.create("브랜드", "설명"))
+            val product = productFacade.registerProduct(
+                ProductCommand.RegisterProduct(brand.id, "상품", "설명", BigDecimal(1000)),
+            )
+
+            val latch = CountDownLatch(userCount)
+            val executor = Executors.newFixedThreadPool(userCount)
+
+            repeat(userCount) { i ->
+                executor.submit {
+                    try {
+                        likeFacade.addLike(AddLike(userId = (i + 1).toLong(), product.id, PRODUCT))
+                    } catch (e: Exception) {
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+
+            latch.await()
+
+            // when
+            val likeCount = likeCountRepository.findCountByTargetIdAndType(product.id, PRODUCT)
+
+            // then
+            assertThat(likeCount?.count?.value?.toInt()).isEqualTo(userCount)
+        }
+
+        @Test
+        fun `여러 유저가 동시에 같은 상품에 좋아요 취소를 요청해도 최종 좋아요 수는 0이어야 한다`() {
+            // given
+            val userCount = 20
+            val brand = brandRepository.save(Brand.create("브랜드", "설명"))
+            val productDetail = productFacade.registerProduct(
+                ProductCommand.RegisterProduct(brand.id, "상품", "설명", BigDecimal(1000)),
+            )
+
+            repeat(userCount) { i ->
+                likeFacade.addLike(AddLike(userId = (i + 1).toLong(), productDetail.id, PRODUCT))
+            }
+
+            val createLikeCount = likeCountRepository.findCountByTargetIdAndType(productDetail.id, PRODUCT)
+            assertThat(createLikeCount?.count?.value?.toInt()).isEqualTo(userCount)
+
+            val latch = CountDownLatch(userCount)
+            val executor = Executors.newFixedThreadPool(userCount)
+
+            repeat(userCount) { i ->
+                executor.submit {
+                    try {
+                        likeFacade.removeLike(LikeCommand.RemoveLike(userId = (i + 1).toLong(), productDetail.id, PRODUCT))
+                    } catch (e: Exception) {
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+
+            latch.await()
+
+            // when
+            val likeCount = likeCountRepository.findCountByTargetIdAndType(productDetail.id, PRODUCT)
+
+            // then
+            assertThat(likeCount?.count?.value).isEqualTo(0)
         }
     }
 }


### PR DESCRIPTION
## 📌 Summary
결제 시 포인트(낙관적), 재고(비관적) 동시성 이슈 방지 [dedcb7a]
좋아요(비관적) 동시성 이슈 방지 [3fd46f9]
쿠폰 도메인 미개발

트랜젝션으로 인한 정합성 처리를 3주차때 작업을 했었기 때문에 관련 코드 스크린샷으로 첨부합니다!
[결제 진행] [[PaymentProcess.kt](https://github.com/HYEONMIN94/loopers-spring-kotlin-template/blob/feature/week4/base/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentProcessor.kt)]
<img width="871" height="729" alt="image" src="https://github.com/user-attachments/assets/55eb7fe1-80b9-44d3-bc49-649d3b50a43a" />

[실패 시 주문, 결제 실패 상태로 전환] [[PaymentStateService.kt](https://github.com/HYEONMIN94/loopers-spring-kotlin-template/blob/feature/week4/base/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentStateService.kt)] [[OrderStateService.kt](https://github.com/HYEONMIN94/loopers-spring-kotlin-template/blob/feature/week4/base/apps/commerce-api/src/main/kotlin/com/loopers/application/order/OrderStateService.kt)]
<img width="493" height="138" alt="image" src="https://github.com/user-attachments/assets/e1afa0c9-fbb6-4a56-800c-a6cefba70aa4" />
<img width="530" height="128" alt="image" src="https://github.com/user-attachments/assets/89b00668-093d-40a7-aa73-79183e07202e" />

## 💬 Review Points
[질문 1] 저의 경우에는 
1. 주문 요청 -> 주문 id 반환
2. 결제 요청(주문 id) -> 결제 id 반환
3. 결제 진행(결제 id) -> 성공 여부 
단계로 이루어져 있는데,
현업에서는 주문, 결제 단계를 어떻게 나누고 요청 실패에 대한 트랜잭션 격리를 어떻게 하는지 궁금합니다.

[질문 2] 락 선택이 잘 이루어졌는지 여쭙고 싶습니다.
- 좋아요 수의 경우에는 비관적 락을 선택하였습니다.
공유 자원, 충돌이 많을 것으로 예상, 데이터가 유실되지 않음(일반적인 상황), 가볍고 자주 사용되는 기능

- 포인트의 경우에는 낙관적 락을 선택했습니다.
개인 자원, 결제에 사용되는 중요성(잘못된 결제 보다는 에러가 낫다고 판단), 충돌이 거의 발생하지 않을거란 예상, 일반적인 시나리오에서 충전, 결제가 동시에 요청하지 않음, 결제도 동시 요청이 일어나지 않지만, 따닥과 같은 중복 요청의 경우 멱등키와 같은 멱등성을 보장하기 위한 다른 방법을 사용하는게 맞다고 판단, 물론 낙관적 락을 통한 중복 결제 방지라는 부수적인 효과 있음

- 재고의 경우에는 비관적 락을 선택했습니다.
공유 자원, 충돌이 어느정도 있을 것으로 예상, 데이터 정합성이 중요

[질문 3] 멱등성과 동시성은 다른 개념으로 알고있습니다. 다만, 낙관적 락의 경우 포인트로 예를들면 포인트 사용이 락을 통해 실패를 하게 된다면 실패처리를 하게 되는 상황이 발생하는데 이는 결국 하나의 결제에 대한 동일한 결과가 진행되어 상태에 대해서는 어느정도  멱등성도 지켜진다고 생각하는데 API응답에 대해서도 잘 처리를 한다면 같은 결과를 받아 응답에서도 멱등성을 지킬 수 있을 것 같긴 한데 락을 통해 멱등성을 보장하는 경우도 있을까요?

## ✅ Checklist

### 🗞️Coupon 도메인

- [ ]  쿠폰은 사용자가 소유하고 있으며, 이미 사용된 쿠폰은 사용할 수 없어야 한다.
- [ ]  쿠폰 종류는 정액 / 정률로 구분되며, 각 적용 로직을 구현하였다.
- [ ]  각 발급된 쿠폰은 최대 한번만 사용될 수 있다.

### 🧾 **주문**

- [x]  주문 전체 흐름에 대해 원자성이 보장되어야 한다.
- [ ]  사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다.
- [x]  재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.
- [x]  주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다
- [x]  쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다.
- [x]  주문 성공 시, 모든 처리는 정상 반영되어야 한다.

### 🧪동시성 테스트

- [x]  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- [ ]  동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다.
- [x]  동일한 유저가 여러 기기에서 동시에 주문에도, 포인트가 중복 차감되지 않아야 한다.
- [x]  동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다.
