### PR TITLE
6주차 과제 제출

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -18,6 +18,12 @@ dependencies {
     // querydsl
     kapt("com.querydsl:querydsl-apt::jakarta")
 
+    // feign client
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    // resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3")
+
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
     testImplementation(testFixtures(project(":modules:redis")))

--- a/apps/commerce-api/src/main/kotlin/com/loopers/CommerceApiApplication.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/CommerceApiApplication.kt
@@ -4,8 +4,10 @@ import jakarta.annotation.PostConstruct
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 import java.util.TimeZone
 
+@EnableFeignClients
 @ConfigurationPropertiesScan
 @SpringBootApplication
 class CommerceApiApplication {

--- a/apps/commerce-api/src/main/kotlin/com/loopers/CommerceApiApplication.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/CommerceApiApplication.kt
@@ -5,8 +5,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.scheduling.annotation.EnableScheduling
 import java.util.TimeZone
 
+@EnableScheduling
 @EnableFeignClients
 @ConfigurationPropertiesScan
 @SpringBootApplication

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentProcessor.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentProcessor.kt
@@ -7,7 +7,7 @@ import com.loopers.domain.order.entity.Order
 import com.loopers.domain.order.entity.OrderItem
 import com.loopers.domain.payment.PaymentService
 import com.loopers.domain.payment.entity.Payment
-import com.loopers.domain.point.PointService
+import com.loopers.domain.payment.strategy.PaymentStrategyRegistry
 import com.loopers.domain.product.ProductStockService
 import com.loopers.domain.product.dto.command.ProductStockCommand
 import com.loopers.domain.product.dto.result.ProductStockResult
@@ -24,34 +24,31 @@ class PaymentProcessor(
     private val orderService: OrderService,
     private val orderItemService: OrderItemService,
     private val productStockService: ProductStockService,
-    private val pointService: PointService,
     private val paymentStateService: PaymentStateService,
     private val orderStateService: OrderStateService,
+    private val paymentStrategyRegistry: PaymentStrategyRegistry,
 ) {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun process(id: Long) {
+        paymentStateService.paymentProcessing(id)
+
         val payment = paymentService.get(id)
         val order = orderService.get(payment.orderId)
-
-        val orderItems = orderItemService.findAll(order.id)
-
         try {
-            processPayment(order, payment, orderItems)
+            processPayment(order, payment)
         } catch (e: Exception) {
             processFailure(order.id, payment.id, resolveFailureReason(e))
             throw e
         }
     }
 
-    private fun processPayment(order: Order, payment: Payment, orderItems: List<OrderItem>) {
+    private fun processPayment(order: Order, payment: Payment) {
+        val orderItems = orderItemService.findAll(order.id)
         val decreaseStocks = getDecreaseStocks(orderItems)
         productStockService.decreaseStocks(decreaseStocks.toCommand())
 
-        val point = pointService.get(order.userId)
-        point.use(payment.paymentPrice.value)
-
-        payment.success()
-        order.success()
+        val paymentStrategy = paymentStrategyRegistry.of(payment.paymentMethod)
+        paymentStrategy.process(order, payment)
     }
 
     private fun processFailure(orderId: Long, paymentId: Long, reason: String) {

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentStateService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentStateService.kt
@@ -10,6 +10,12 @@ class PaymentStateService(
     private val paymentService: PaymentService,
 ) {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun paymentProcessing(paymentId: Long) {
+        val payment = paymentService.get(paymentId)
+        payment.processing()
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun paymentFailure(paymentId: Long, reason: String) {
         val payment = paymentService.get(paymentId)
         payment.failure(reason)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/entity/Order.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/entity/Order.kt
@@ -66,7 +66,7 @@ class Order protected constructor(
         status = Status.ORDER_SUCCESS
     }
 
-    fun failure(reason: String) {
+    fun failure(reason: String?) {
         if (status != Status.PAYMENT_REQUEST) {
             throw CoreException(ErrorType.CONFLICT, "결제 요청 상태에서만 주문 실패가 가능합니다.")
         }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
@@ -5,5 +5,7 @@ import com.loopers.domain.payment.entity.Payment
 interface PaymentRepository {
     fun find(id: Long): Payment?
 
+    fun find(transactionKey: String): Payment?
+
     fun save(payment: Payment): Payment
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
@@ -8,4 +8,6 @@ interface PaymentRepository {
     fun find(transactionKey: String): Payment?
 
     fun save(payment: Payment): Payment
+
+    fun findByStatus(status: Payment.Status): List<Payment>
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentSchedulerService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentSchedulerService.kt
@@ -1,0 +1,75 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.order.OrderService
+import com.loopers.domain.payment.entity.Payment
+import com.loopers.domain.payment.type.TransactionStatus
+import com.loopers.infrastructure.pg.PgClient
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PaymentSchedulerService(
+    private val paymentService: PaymentService,
+    private val orderService: OrderService,
+    private val pgClient: PgClient,
+) {
+    data class PgSchedulerResponse(
+        val status: TransactionStatus?,
+        val transactionKey: String?,
+        val reason: String?,
+    )
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun reconcileOne(paymentId: Long) {
+        val payment = paymentService.get(paymentId)
+
+        if (payment.status != Payment.Status.PROCESSING) {
+            return
+        }
+
+        val order = orderService.get(payment.orderId)
+        val userId = order.userId
+
+        val snap: PgSchedulerResponse = try {
+            if (payment.transactionKey != null) {
+                val response = pgClient.getTransaction(userId, payment.transactionKey!!)
+                val data = response.data
+                PgSchedulerResponse(
+                    status = data?.status,
+                    transactionKey = data?.transactionKey ?: payment.transactionKey,
+                    reason = data?.reason,
+                )
+            } else {
+                val response = pgClient.getOrder(userId, "LOOPERS-${order.id}")
+                val transactions = response.data?.transactions?.firstOrNull()
+                PgSchedulerResponse(
+                    status = transactions?.status,
+                    transactionKey = transactions?.transactionKey,
+                    reason = transactions?.reason,
+                )
+            }
+        } catch (e: Exception) {
+            return
+        }
+
+        if (payment.transactionKey == null && !snap.transactionKey.isNullOrBlank()) {
+            payment.updateTransactionKey(snap.transactionKey)
+        }
+
+        when (snap.status) {
+            TransactionStatus.SUCCESS -> {
+                payment.success()
+                order.success()
+            }
+            TransactionStatus.FAILED -> {
+                val reason = snap.reason
+                payment.failure(reason)
+                order.failure(reason)
+            }
+            TransactionStatus.PENDING, null -> {
+                // TODO: 그럼에도 불구하고 펜딩상태면... PG사쪽에 문의가 필요하지 않을까 싶습니다
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentService.kt
@@ -11,7 +11,15 @@ class PaymentService(
 ) {
     fun get(id: Long): Payment {
         return paymentRepository.find(id)
-            ?: throw CoreException(errorType = ErrorType.NOT_FOUND, customMessage = "[id = $id] 주문을 찾을 수 없습니다.")
+            ?: throw CoreException(errorType = ErrorType.NOT_FOUND, customMessage = "[id = $id] 결제를 찾을 수 없습니다.")
+    }
+
+    fun get(transactionKey: String): Payment {
+        return paymentRepository.find(transactionKey)
+            ?: throw CoreException(
+                errorType = ErrorType.NOT_FOUND,
+                customMessage = "[transactionKey = $transactionKey] 결제를 찾을 수 없습니다.",
+            )
     }
 
     fun request(payment: Payment): Payment {

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/dto/command/PaymentCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/dto/command/PaymentCommand.kt
@@ -2,20 +2,60 @@ package com.loopers.domain.payment.dto.command
 
 import com.loopers.domain.payment.entity.Payment
 import com.loopers.domain.payment.entity.Payment.Method
+import com.loopers.domain.payment.type.CardType
+import com.loopers.domain.payment.type.TransactionStatus
 import java.math.BigDecimal
 
 class PaymentCommand {
     data class Request(
         val orderId: Long,
         val paymentMethod: Method,
+        val cardType: String,
+        val cardNumber: String,
     ) {
         fun toEntity(paymentPrice: BigDecimal): Payment {
-            return Payment.create(orderId, paymentMethod, paymentPrice, Payment.Status.REQUESTED)
+            var payment = Payment.create(orderId, paymentMethod, paymentPrice, Payment.Status.REQUESTED, cardType, cardNumber)
+            if (paymentMethod == Method.POINT) {
+                payment = Payment.create(orderId, paymentMethod, paymentPrice, Payment.Status.REQUESTED)
+            }
+            return payment
         }
 
         companion object {
-            fun of(orderId: Long, paymentMethod: Method): Request {
-                return Request(orderId, paymentMethod)
+            fun of(orderId: Long, paymentMethod: Method, cardType: String, cardNumber: String): Request {
+                return Request(orderId, paymentMethod, cardType, cardNumber)
+            }
+        }
+    }
+
+    data class PaymentWebhook(
+        val transactionKey: String,
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val status: TransactionStatus,
+        val reason: String?,
+    ) {
+        companion object {
+            fun of(
+                transactionKey: String,
+                   orderId: String,
+                   cardType: CardType,
+                   cardNo: String,
+                   amount: Long,
+                   status: TransactionStatus,
+                   reason: String?,
+            ): PaymentWebhook {
+                return PaymentWebhook(
+                    transactionKey,
+                    orderId,
+                    cardType,
+                    cardNo,
+                    amount,
+                    status,
+                    reason,
+                    )
             }
         }
     }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/scheduler/PaymentScheduler.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/scheduler/PaymentScheduler.kt
@@ -1,0 +1,28 @@
+package com.loopers.domain.payment.scheduler
+
+import com.loopers.domain.payment.PaymentRepository
+import com.loopers.domain.payment.PaymentSchedulerService
+import com.loopers.domain.payment.entity.Payment
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentScheduler(
+    private val paymentRepository: PaymentRepository,
+    private val paymentSchedulerService: PaymentSchedulerService,
+) {
+    @Scheduled(fixedDelayString = "60000")
+    fun reconcile() {
+        // TODO: 시간 및 처리 데이터 테이블들 별도로 만들어 체크해야함
+
+        val processingPayment: List<Payment> = paymentRepository.findByStatus(Payment.Status.PROCESSING)
+
+        if (processingPayment.isEmpty()) {
+            return
+        }
+
+        processingPayment.forEach {
+            paymentSchedulerService.reconcileOne(it.id)
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/strategy/CreditCardPaymentStrategy.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/strategy/CreditCardPaymentStrategy.kt
@@ -1,0 +1,43 @@
+package com.loopers.domain.payment.strategy
+
+import com.loopers.domain.order.entity.Order
+import com.loopers.domain.payment.entity.Payment
+import com.loopers.domain.payment.type.CardType
+import com.loopers.infrastructure.pg.PgDto
+import com.loopers.infrastructure.pg.PgGateway
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class CreditCardPaymentStrategy(
+    private val pgGateway: PgGateway,
+) : PaymentStrategy {
+    override fun supports() = Payment.Method.CREDIT_CARD
+
+    @Transactional
+    override fun process(order: Order, payment: Payment) {
+        val req = PgDto.PaymentRequest(
+            orderId = "LOOPERS-" + order.id,
+            cardType = CardType.of(payment.cardType),
+            cardNo = payment.cardNumber,
+            amount = payment.paymentPrice.value.toLong(),
+            callbackUrl = "http://localhost:8080/api/v1/payments/webhook",
+        )
+
+        when (val result = pgGateway.payment(order.userId, req)) {
+            is PgGateway.Result.Ok -> {
+                payment.updateTransactionKey(result.transactionKey)
+            }
+
+            is PgGateway.Result.BadRequest -> {
+                payment.failure(result.message)
+                order.failure(result.message)
+            }
+
+            is PgGateway.Result.Retryable -> {
+                payment.failure(result.message)
+                order.failure(result.message)
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/strategy/PaymentStrategy.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/strategy/PaymentStrategy.kt
@@ -1,0 +1,9 @@
+package com.loopers.domain.payment.strategy
+
+import com.loopers.domain.order.entity.Order
+import com.loopers.domain.payment.entity.Payment
+
+interface PaymentStrategy {
+    fun supports(): Payment.Method
+    fun process(order: Order, payment: Payment)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/strategy/PaymentStrategyRegistry.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/strategy/PaymentStrategyRegistry.kt
@@ -1,0 +1,13 @@
+package com.loopers.domain.payment.strategy
+
+import com.loopers.domain.payment.entity.Payment
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentStrategyRegistry(strategies: List<PaymentStrategy>) {
+    private val map = strategies.associateBy { it.supports() }
+    fun of(method: Payment.Method): PaymentStrategy =
+        map[method] ?: throw CoreException(ErrorType.INTERNAL_ERROR, "결제 수단에 대한 결제 방법이 없습니다 (method = $method)")
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/strategy/PointPaymentStrategy.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/strategy/PointPaymentStrategy.kt
@@ -1,0 +1,24 @@
+package com.loopers.domain.payment.strategy
+
+import com.loopers.domain.order.entity.Order
+import com.loopers.domain.payment.entity.Payment
+import com.loopers.domain.point.PointService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PointPaymentStrategy(
+    private val pointService: PointService,
+) : PaymentStrategy {
+
+    override fun supports() = Payment.Method.POINT
+
+    @Transactional
+    override fun process(order: Order, payment: Payment) {
+        val point = pointService.get(order.userId)
+        point.use(payment.paymentPrice.value)
+
+        payment.success()
+        order.success()
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/type/CardType.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/type/CardType.kt
@@ -1,0 +1,14 @@
+package com.loopers.domain.payment.type
+
+enum class CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+    ;
+
+    companion object {
+        fun of(type: String?): CardType =
+            values().firstOrNull { it.name.equals(type, ignoreCase = true) }
+                ?: throw IllegalArgumentException("지원하지 않는 카드 타입: $type")
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/type/TransactionStatus.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/type/TransactionStatus.kt
@@ -1,0 +1,14 @@
+package com.loopers.domain.payment.type
+
+enum class TransactionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED,
+    ;
+
+    companion object {
+        fun of(type: String?): TransactionStatus =
+            values().firstOrNull { it.name.equals(type, ignoreCase = true) }
+                ?: throw IllegalArgumentException("지원하지 않는 카드 타입: $type")
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
@@ -3,4 +3,6 @@ package com.loopers.infrastructure.payment
 import com.loopers.domain.payment.entity.Payment
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface PaymentJpaRepository : JpaRepository<Payment, Long>
+interface PaymentJpaRepository : JpaRepository<Payment, Long> {
+    fun findByTransactionKey(transactionKey: String): Payment?
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface PaymentJpaRepository : JpaRepository<Payment, Long> {
     fun findByTransactionKey(transactionKey: String): Payment?
+
+    fun findAllByStatus(status: Payment.Status): List<Payment>
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentRepositoryImpl.kt
@@ -13,6 +13,10 @@ class PaymentRepositoryImpl(
         return paymentJpaRepository.findByIdOrNull(id)
     }
 
+    override fun find(transactionKey: String): Payment? {
+        return paymentJpaRepository.findByTransactionKey(transactionKey)
+    }
+
     override fun save(payment: Payment): Payment {
         return paymentJpaRepository.save(payment)
     }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentRepositoryImpl.kt
@@ -20,4 +20,8 @@ class PaymentRepositoryImpl(
     override fun save(payment: Payment): Payment {
         return paymentJpaRepository.save(payment)
     }
+
+    override fun findByStatus(status: Payment.Status): List<Payment> {
+        return paymentJpaRepository.findAllByStatus(status)
+    }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/pg/PgClient.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/pg/PgClient.kt
@@ -1,0 +1,35 @@
+package com.loopers.infrastructure.pg
+
+import com.loopers.interfaces.api.ApiResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(
+    name = "pgClient",
+    url = "http://localhost:8082",
+    configuration = [PgFeignTimeoutConfig::class],
+)
+interface PgClient {
+    @PostMapping("/api/v1/payments")
+    fun payment(
+        @RequestHeader("X-USER-ID") userId: Long,
+        @RequestBody body: PgDto.PaymentRequest,
+    ): ApiResponse<PgDto.TransactionResponse>
+
+    @GetMapping("/api/v1/payments/{transactionKey}")
+    fun getTransaction(
+        @RequestHeader("X-USER-ID") userId: Long,
+        @PathVariable transactionKey: String,
+    ): ApiResponse<PgDto.TransactionDetailResponse>
+
+    @GetMapping("/api/v1/payments")
+    fun getOrder(
+        @RequestHeader("X-USER-ID") userId: Long,
+        @RequestParam("orderId") orderId: String,
+    ): ApiResponse<PgDto.OrderResponse>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/pg/PgDto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/pg/PgDto.kt
@@ -1,0 +1,61 @@
+package com.loopers.infrastructure.pg
+
+import com.loopers.domain.payment.type.CardType
+import com.loopers.domain.payment.type.TransactionStatus
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PgDto {
+    data class PaymentRequest(
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String?,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            private val REGEX_CARD_NO = Regex("^\\d{4}-\\d{4}-\\d{4}-\\d{4}$")
+            private const val PREFIX_CALLBACK_URL = "http://localhost:8080"
+        }
+
+        fun validate() {
+            if (orderId.isBlank() || orderId.length < 6) {
+                throw CoreException(ErrorType.BAD_REQUEST, "주문 ID는 6자리 이상 문자열이어야 합니다.")
+            }
+            if (!REGEX_CARD_NO.matches(cardNo.orEmpty())) {
+                throw CoreException(ErrorType.BAD_REQUEST, "카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.")
+            }
+            if (amount <= 0) {
+                throw CoreException(ErrorType.BAD_REQUEST, "결제금액은 양의 정수여야 합니다.")
+            }
+            if (!callbackUrl.startsWith(PREFIX_CALLBACK_URL)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "콜백 URL 은 $PREFIX_CALLBACK_URL 로 시작해야 합니다.")
+            }
+        }
+
+        init {
+            validate()
+        }
+    }
+
+    data class TransactionDetailResponse(
+        val transactionKey: String,
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val status: TransactionStatus,
+        val reason: String?,
+    )
+
+    data class TransactionResponse(
+        val transactionKey: String,
+        val status: TransactionStatus,
+        val reason: String?,
+    )
+
+    data class OrderResponse(
+        val orderId: String,
+        val transactions: List<TransactionResponse>,
+    )
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/pg/PgFeignTimeoutConfig.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/pg/PgFeignTimeoutConfig.kt
@@ -1,0 +1,11 @@
+package com.loopers.infrastructure.pg
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class PgFeignTimeoutConfig {
+    @Bean
+    fun feignOptions(): feign.Request.Options =
+        feign.Request.Options(1000, 3000)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/pg/PgGateway.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/pg/PgGateway.kt
@@ -1,0 +1,49 @@
+package com.loopers.infrastructure.pg
+
+import feign.FeignException
+import feign.RetryableException
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
+import org.springframework.stereotype.Component
+
+@Component
+class PgGateway(
+    private val pgClient: PgClient,
+) {
+    sealed interface Result {
+        data class Ok(val transactionKey: String) : Result
+        data class BadRequest(val message: String?) : Result
+        data class Retryable(val message: String?) : Result
+    }
+
+    @CircuitBreaker(name = "pg")
+    @Retry(name = "payment", fallbackMethod = "fallback")
+    fun payment(userId: Long, req: PgDto.PaymentRequest): Result {
+        val resp = pgClient.payment(userId, req)
+
+        val transactionKey = resp.data?.transactionKey
+            ?: throw IllegalStateException("트랜잭션키를 받지 못했습니다.")
+
+        return Result.Ok(transactionKey)
+    }
+
+    fun fallback(userId: Long, request: PgDto.PaymentRequest, ex: Throwable): Result {
+        return when (ex) {
+            is FeignException.FeignClientException -> {
+                Result.BadRequest(ex.message ?: "bad request")
+            }
+            is FeignException.FeignServerException -> {
+                Result.Retryable("PG FeignServerException: ${ex.message ?: ""}".trim())
+            }
+            is RetryableException -> {
+                Result.Retryable("PG RetryableException: ${ex.message ?: ""}".trim())
+            }
+            is java.util.concurrent.TimeoutException -> {
+                Result.Retryable("PG TimeoutException: ${ex.message ?: ""}".trim())
+            }
+            else -> {
+                Result.Retryable("PG error: ${ex.message ?: ""}".trim())
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
@@ -32,6 +32,7 @@ class ApiControllerAdvice {
 
     @ExceptionHandler
     fun handleBadRequest(e: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<*>> {
+        log.warn("MethodArgumentTypeMismatchException : {}", e.message, e)
         val name = e.name
         val type = e.requiredType?.simpleName ?: "unknown"
         val value = e.value ?: "null"
@@ -41,6 +42,7 @@ class ApiControllerAdvice {
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<ApiResponse<*>> {
+        log.warn("MethodArgumentNotValidException : {}", e.message, e)
         val message = e.bindingResult.fieldErrors.joinToString(", ") { fieldError ->
             val field = fieldError.field
             val rejectedValue = fieldError.rejectedValue ?: "null"
@@ -59,6 +61,7 @@ class ApiControllerAdvice {
 
     @ExceptionHandler
     fun handleBadRequest(e: MissingServletRequestParameterException): ResponseEntity<ApiResponse<*>> {
+        log.warn("MissingServletRequestParameterException : {}", e.message, e)
         val name = e.parameterName
         val type = e.parameterType
         val message = "필수 요청 파라미터 '$name' (타입: $type)가 누락되었습니다."
@@ -67,6 +70,7 @@ class ApiControllerAdvice {
 
     @ExceptionHandler
     fun handleBadRequest(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<*>> {
+        log.warn("HttpMessageNotReadableException : {}", e.message, e)
         val errorMessage = when (val rootCause = e.rootCause) {
             is InvalidFormatException -> {
                 val fieldName = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
@@ -105,6 +109,7 @@ class ApiControllerAdvice {
 
     @ExceptionHandler
     fun handleBadRequest(e: ServerWebInputException): ResponseEntity<ApiResponse<*>> {
+        log.warn("ServerWebInputException : {}", e.message, e)
         fun extractMissingParameter(message: String): String {
             val regex = "'(.+?)'".toRegex()
             return regex.find(message)?.groupValues?.get(1) ?: ""
@@ -120,6 +125,7 @@ class ApiControllerAdvice {
 
     @ExceptionHandler
     fun handleNotFound(e: NoResourceFoundException): ResponseEntity<ApiResponse<*>> {
+        log.warn("NoResourceFoundException : {}", e.message, e)
         return failureResponse(errorType = ErrorType.NOT_FOUND)
     }
 

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1ApiSpec.kt
@@ -11,7 +11,7 @@ interface OrderV1ApiSpec {
         summary = "주문 요청",
         description = "주문을 요청 합니다.",
     )
-    fun request(
+    fun requestOrder(
         @Schema(name = "주문 요청 정보", description = "주문 요청 정보")
         request: OrderV1Dto.OrderRequest,
     ): ApiResponse<OrderV1Dto.OrderResponse>

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Controller.kt
@@ -15,8 +15,8 @@ class OrderV1Controller(
     private val orderFacade: OrderFacade,
 ) : OrderV1ApiSpec {
     @Authenticated
-    @PostMapping("request")
-    override fun request(
+    @PostMapping("")
+    override fun requestOrder(
         @Valid @RequestBody request: OrderV1Dto.OrderRequest,
     ): ApiResponse<OrderV1Dto.OrderResponse> {
         return orderFacade.requestOrder(request.toRequestOrder())

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.kt
@@ -13,4 +13,6 @@ interface PaymentV1ApiSpec {
     fun requestPayment(request: PaymentV1Dto.PaymentRequest): ApiResponse<PaymentV1Dto.PaymentResponse>
 
     fun processPayment(id: Long)
+
+    fun processPaymentWebhook(request: PaymentV1Dto.WebhookRequest)
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentV1Controller.kt
@@ -3,8 +3,9 @@ package com.loopers.interfaces.api.payment
 import com.loopers.application.payment.PaymentFacade
 import com.loopers.interfaces.api.ApiResponse
 import com.loopers.support.auth.annotation.Authenticated
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -14,16 +15,20 @@ class PaymentV1Controller(
     private val paymentFacade: PaymentFacade,
 ) : PaymentV1ApiSpec {
     @Authenticated
-    @GetMapping("")
-    override fun requestPayment(request: PaymentV1Dto.PaymentRequest): ApiResponse<PaymentV1Dto.PaymentResponse> {
+    @PostMapping("")
+    override fun requestPayment(@RequestBody request: PaymentV1Dto.PaymentRequest): ApiResponse<PaymentV1Dto.PaymentResponse> {
         return paymentFacade.requestPayment(request.toCommand())
             .let { PaymentV1Dto.PaymentResponse.from(it) }
             .let { ApiResponse.success(it) }
     }
 
-    @Authenticated
-    @GetMapping("/{id}/process")
+    @PostMapping("/{id}/process")
     override fun processPayment(@PathVariable id: Long) {
-        return paymentFacade.processPayment(id)
+        paymentFacade.processPayment(id)
+    }
+
+    @PostMapping("/webhook")
+    override fun processPaymentWebhook(@RequestBody request: PaymentV1Dto.WebhookRequest) {
+        paymentFacade.processPaymentWebhook(request.toCommand())
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentV1Dto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentV1Dto.kt
@@ -4,8 +4,11 @@ import com.loopers.domain.payment.dto.command.PaymentCommand
 import com.loopers.domain.payment.dto.result.PaymentResult
 import com.loopers.domain.payment.entity.Payment.Method
 import com.loopers.domain.payment.entity.Payment.Status
+import com.loopers.domain.payment.type.CardType
+import com.loopers.domain.payment.type.TransactionStatus
 import java.math.BigDecimal
 import java.time.ZonedDateTime
+import kotlin.String
 
 class PaymentV1Dto {
     data class PaymentResponse(
@@ -38,9 +41,33 @@ class PaymentV1Dto {
     data class PaymentRequest(
         val orderId: Long,
         val paymentMethod: Method,
+        val cardType: String,
+        val cardNumber: String,
     ) {
         fun toCommand(): PaymentCommand.Request {
-            return PaymentCommand.Request.of(orderId, paymentMethod)
+            return PaymentCommand.Request.of(orderId, paymentMethod, cardType, cardNumber)
+        }
+    }
+
+    data class WebhookRequest(
+        val transactionKey: String,
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val status: TransactionStatus,
+        val reason: String?,
+    ) {
+        fun toCommand(): PaymentCommand.PaymentWebhook {
+            return PaymentCommand.PaymentWebhook.of(
+                transactionKey,
+                orderId,
+                cardType,
+                cardNo,
+                amount,
+                status,
+                reason,
+            )
         }
     }
 }

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -23,6 +23,38 @@ spring:
       - redis.yml
       - logging.yml
       - monitoring.yml
+  datasource:
+    hikari:
+      connection-timeout: 3000       # 커넥션 풀에서 커넥션 얻는 최대 대기 시간
+      validation-timeout: 2000       # 커넥션 유효성 검사 제한 시간
+
+resilience4j:
+  retry:
+    instances:
+      payment:
+        maxAttempts: 3
+        waitDuration: 300ms
+        retryExceptions:
+          - feign.FeignException.FeignServerException
+          - feign.RetryableException
+        ignoreExceptions:
+          - feign.FeignException.FeignClientException
+  circuitbreaker:
+    instances:
+      pg:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 20
+        failureRateThreshold: 50
+        slowCallDurationThreshold: 2s
+        slowCallRateThreshold: 50
+        waitDurationInOpenState: 10s
+        permittedNumberOfCallsInHalfOpenState: 3
+        recordExceptions:
+          - feign.FeignException.FeignServerException
+          - feign.RetryableException
+          - java.util.concurrent.TimeoutException
+        ignoreExceptions:
+          - feign.FeignException.FeignClientException
 
 springdoc:
   use-fqn: true

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/payment/PaymentProcessorIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/payment/PaymentProcessorIntegrationTest.kt
@@ -88,7 +88,7 @@ class PaymentProcessorIntegrationTest @Autowired constructor(
             orderItemService.register(orderCommand.toItemCommand(order.id))
 
             val payment = paymentService.request(
-                PaymentCommand.Request(order.id, Payment.Method.POINT).toEntity(BigDecimal("1000")),
+                PaymentCommand.Request(order.id, Payment.Method.POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal("1000")),
             )
 
             // when
@@ -127,7 +127,7 @@ class PaymentProcessorIntegrationTest @Autowired constructor(
             orderItemService.register(orderCommand.toItemCommand(order.id))
 
             val payment = paymentService.request(
-                PaymentCommand.Request(order.id, Payment.Method.POINT).toEntity(BigDecimal("1000")),
+                PaymentCommand.Request(order.id, Payment.Method.POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal("1000")),
             )
 
             // expect
@@ -165,7 +165,7 @@ class PaymentProcessorIntegrationTest @Autowired constructor(
             orderItemService.register(orderCommand.toItemCommand(order.id))
 
             val payment = paymentService.request(
-                PaymentCommand.Request(order.id, Payment.Method.POINT).toEntity(BigDecimal("1000")),
+                PaymentCommand.Request(order.id, Payment.Method.POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal("1000")),
             )
 
             // expect
@@ -205,7 +205,7 @@ class PaymentProcessorIntegrationTest @Autowired constructor(
             orderItemService.register(orderCommand.toItemCommand(order.id))
 
             val payment = paymentService.request(
-                PaymentCommand.Request(order.id, Payment.Method.POINT).toEntity(BigDecimal("1000")),
+                PaymentCommand.Request(order.id, Payment.Method.POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal("1000")),
             )
 
             // when
@@ -252,7 +252,7 @@ class PaymentProcessorIntegrationTest @Autowired constructor(
             orderItemService.register(orderCommand.toItemCommand(order.id))
 
             val payment = paymentService.request(
-                PaymentCommand.Request(order.id, Payment.Method.POINT).toEntity(BigDecimal("1000")),
+                PaymentCommand.Request(order.id, Payment.Method.POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal("1000")),
             )
 
             // when
@@ -301,7 +301,7 @@ class PaymentProcessorIntegrationTest @Autowired constructor(
             orderItemService.register(orderCommand.toItemCommand(order.id))
 
             val payment = paymentService.request(
-                PaymentCommand.Request(order.id, Payment.Method.POINT).toEntity(BigDecimal("2000")),
+                PaymentCommand.Request(order.id, Payment.Method.POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal("2000")),
             )
 
             // when
@@ -357,7 +357,7 @@ class PaymentProcessorIntegrationTest @Autowired constructor(
             orderItemService.register(orderCommand.toItemCommand(order.id))
 
             val payment = paymentService.request(
-                PaymentCommand.Request(order.id, Payment.Method.POINT).toEntity(BigDecimal(totalPrice)),
+                PaymentCommand.Request(order.id, Payment.Method.POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal(totalPrice)),
             )
 
             var failCount = 0
@@ -426,7 +426,7 @@ class PaymentProcessorIntegrationTest @Autowired constructor(
                         orderItemService.register(orderCommand.toItemCommand(order.id))
 
                         val payment = paymentService.request(
-                            PaymentCommand.Request(order.id, Payment.Method.POINT).toEntity(BigDecimal(totalPrice)),
+                            PaymentCommand.Request(order.id, Payment.Method.POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal(totalPrice)),
                         )
 
                         paymentProcessor.process(payment.id)
@@ -489,7 +489,7 @@ class PaymentProcessorIntegrationTest @Autowired constructor(
                         orderItemService.register(orderCommand.toItemCommand(order.id))
 
                         val payment = paymentService.request(
-                            PaymentCommand.Request(order.id, Payment.Method.POINT).toEntity(BigDecimal(totalPrice)),
+                            PaymentCommand.Request(order.id, Payment.Method.POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal(totalPrice)),
                         )
 
                         paymentProcessor.process(payment.id)

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentSchedulerServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentSchedulerServiceIntegrationTest.kt
@@ -1,0 +1,220 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.order.OrderService
+import com.loopers.domain.order.entity.Order
+import com.loopers.domain.payment.entity.Payment
+import com.loopers.domain.payment.type.CardType
+import com.loopers.domain.payment.type.TransactionStatus
+import com.loopers.infrastructure.pg.PgClient
+import com.loopers.infrastructure.pg.PgDto
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.utils.DatabaseCleanUp
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.kotlin.mock
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.math.BigDecimal
+import kotlin.String
+
+@SpringBootTest
+class PaymentSchedulerServiceIntegrationTest @Autowired constructor(
+    private val scheduler: PaymentSchedulerService,
+    private val paymentService: PaymentService,
+    private val paymentRepository: PaymentRepository,
+    private val databaseCleanUp: DatabaseCleanUp,
+) {
+
+    @MockitoBean
+    private lateinit var pgClient: PgClient
+
+    @MockitoBean
+    private lateinit var orderService: OrderService
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncateAllTables()
+    }
+
+    private fun saveProcessingPayment(
+        orderId: Long = 100L,
+        transactionKey: String? = null,
+    ): Payment {
+        val p = Payment.create(
+            orderId = orderId,
+            paymentMethod = Payment.Method.CREDIT_CARD,
+            paymentPrice = BigDecimal("1000"),
+            status = Payment.Status.PROCESSING,
+            cardType = "KB",
+            cardNumber = "1111-2222-3333-4444",
+        )
+        if (transactionKey != null) p.updateTransactionKey(transactionKey)
+        return paymentRepository.save(p)
+    }
+
+    private fun saveNonProcessingPayment(
+        orderId: Long = 200L,
+    ): Payment {
+        return paymentRepository.save(
+            Payment.create(
+                orderId = orderId,
+                paymentMethod = Payment.Method.CREDIT_CARD,
+                paymentPrice = BigDecimal("500"),
+                status = Payment.Status.REQUESTED,
+                cardType = "KB",
+                cardNumber = "1111-2222-3333-4444",
+            ),
+        )
+    }
+
+    private fun mockOrder(orderId: Long, userId: Long = 1L): Order {
+        val order = mock<Order> {
+            on { this.id }.thenReturn(orderId)
+            on { this.userId }.thenReturn(userId)
+        }
+        given(orderService.get(orderId)).willReturn(order)
+        return order
+    }
+
+    @DisplayName("PG 결과 동기화")
+    @Nested
+    inner class ReconcileOne {
+
+        @Test
+        fun `PG가 성공하면 결제 주문을 성공처리 한다`() {
+            // given
+            val payment = saveProcessingPayment(orderId = 1L, transactionKey = "TRANSACTION_KEY")
+            val order = mockOrder(payment.orderId, userId = 1L)
+
+            given(pgClient.getTransaction(order.userId, "TRANSACTION_KEY"))
+                .willReturn(
+                    ApiResponse.success(
+                        PgDto.TransactionDetailResponse(
+                            transactionKey = "TRANSACTION_KEY",
+                            orderId = "LOPPERS-1",
+                            cardType = CardType.KB,
+                            cardNo = "1111-2222-3333-4444",
+                            amount = 1000L,
+                            status = TransactionStatus.SUCCESS,
+                            reason = null,
+                        ),
+                    ),
+                )
+
+            // when
+            scheduler.reconcileOne(payment.id)
+
+            // then
+            val updated = paymentService.get(payment.id)
+            assertThat(updated.status).isEqualTo(Payment.Status.SUCCESS)
+        }
+
+        @Test
+        fun `PG가 실패면 결제, 주문을 실패처리 한다`() {
+            // given
+            val payment = saveProcessingPayment(orderId = 1L, transactionKey = "TRANSACTION_KEY")
+            val order = mockOrder(payment.orderId, userId = 1L)
+
+            given(pgClient.getTransaction(order.userId, "TRANSACTION_KEY"))
+                .willReturn(
+                    ApiResponse.success(
+                        PgDto.TransactionDetailResponse(
+                            transactionKey = "TRANSACTION_KEY",
+                            orderId = "LOPPERS-1",
+                            cardType = CardType.KB,
+                            cardNo = "1111-2222-3333-4444",
+                            amount = 1000L,
+                            status = TransactionStatus.FAILED,
+                            reason = "잔액부족이요",
+                        ),
+                    ),
+                )
+
+            // when
+            scheduler.reconcileOne(payment.id)
+
+            // then
+            val updated = paymentService.get(payment.id)
+            assertThat(updated.status).isEqualTo(Payment.Status.FAILED)
+        }
+
+        @Test
+        fun `PG가 대기면 결제는 아무런 상태 변경을 하지 않고 프로세싱 상태이어야 한다`() {
+            // given
+            val payment = saveProcessingPayment(orderId = 1L, transactionKey = "TRANSACTION_KEY")
+            val order = mockOrder(payment.orderId, userId = 1L)
+
+            given(pgClient.getTransaction(order.userId, "TRANSACTION_KEY"))
+                .willReturn(
+                    ApiResponse.success(
+                        PgDto.TransactionDetailResponse(
+                            transactionKey = "TRANSACTION_KEY",
+                            orderId = "LOPPERS-1",
+                            cardType = CardType.KB,
+                            cardNo = "1111-2222-3333-4444",
+                            amount = 1000L,
+                            status = TransactionStatus.PENDING,
+                            reason = null,
+                        ),
+                    ),
+                )
+
+            // when
+            scheduler.reconcileOne(payment.id)
+
+            // then
+            val updated = paymentService.get(payment.id)
+            assertThat(updated.status).isEqualTo(Payment.Status.PROCESSING)
+        }
+
+        @Test
+        fun `트랜잭션키가 없으면 주문 기반 조회로 키를 채워 넣는다`() {
+            // given
+            val payment = saveProcessingPayment(orderId = 1L, transactionKey = null)
+            val order = mockOrder(payment.orderId, userId = 1L)
+
+            given(pgClient.getOrder(order.userId, "LOOPERS-${order.id}"))
+                .willReturn(
+                    ApiResponse.success(
+                        PgDto.OrderResponse(
+                            orderId = "LOPPERS-1",
+                            transactions = listOf(
+                                PgDto.TransactionResponse(
+                                    transactionKey = "TRANSACTION_KEY",
+                                    status = TransactionStatus.PENDING,
+                                    reason = null,
+                                ),
+                            ),
+                        ),
+                    ),
+                )
+
+            // when
+            scheduler.reconcileOne(payment.id)
+
+            // then
+            val updated = paymentService.get(payment.id)
+            assertThat(updated.transactionKey).isEqualTo("TRANSACTION_KEY")
+            assertThat(updated.status).isEqualTo(Payment.Status.PROCESSING)
+        }
+
+        @Test
+        fun `PROCESSING이 아니면 아무런 행위도 하지 않고 리턴한다`() {
+            // given
+            val payment = saveNonProcessingPayment(orderId = 1L)
+            val order = mockOrder(payment.orderId, userId = 1L)
+
+            // when
+            scheduler.reconcileOne(payment.id)
+
+            // then
+            val reloaded = paymentService.get(payment.id)
+            assertThat(reloaded.status).isEqualTo(Payment.Status.REQUESTED)
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentServiceIntegrationTest.kt
@@ -34,7 +34,7 @@ class PaymentServiceIntegrationTest @Autowired constructor(
         @Test
         fun `결제를 요청하면 저장된다`() {
             // given
-            val create = PaymentCommand.Request(1L, POINT).toEntity(BigDecimal("1000"))
+            val create = PaymentCommand.Request(1L, POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal("1000"))
 
             // when
             val payment = paymentService.request(create)
@@ -50,7 +50,7 @@ class PaymentServiceIntegrationTest @Autowired constructor(
         fun `0보다 작은 금액을 결제 요청하면 예외가 발생한다`() {
             // expect
             assertThrows<CoreException> {
-                val create = PaymentCommand.Request(1L, POINT).toEntity(BigDecimal("-1"))
+                val create = PaymentCommand.Request(1L, POINT, "KB", "1111-2222-3333-4444").toEntity(BigDecimal("-1"))
                 paymentService.request(create)
             }
         }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentTest.kt
@@ -3,6 +3,7 @@ package com.loopers.domain.payment
 import com.loopers.domain.payment.entity.Payment
 import com.loopers.domain.payment.entity.Payment.Method.POINT
 import com.loopers.domain.payment.entity.Payment.Status.FAILED
+import com.loopers.domain.payment.entity.Payment.Status.PROCESSING
 import com.loopers.domain.payment.entity.Payment.Status.REQUESTED
 import com.loopers.domain.payment.entity.Payment.Status.SUCCESS
 import com.loopers.support.error.CoreException
@@ -27,7 +28,7 @@ class PaymentTest {
     @Test
     fun `결제를 성공 상태로 변경한다`() {
         // given
-        val payment = Payment.create(1L, POINT, BigDecimal("1"), REQUESTED)
+        val payment = Payment.create(1L, POINT, BigDecimal("1"), PROCESSING)
 
         // when
         payment.success()
@@ -39,7 +40,7 @@ class PaymentTest {
     @Test
     fun `결제를 실패 상태로 변경한다`() {
         // given
-        val payment = Payment.create(1L, POINT, BigDecimal("1"), REQUESTED)
+        val payment = Payment.create(1L, POINT, BigDecimal("1"), PROCESSING)
 
         // when
         payment.failure("failReason")
@@ -57,9 +58,9 @@ class PaymentTest {
     }
 
     @Test
-    fun `결제 요청 상태일 때 주문을 성공 처리할 수 있다`() {
+    fun `결제 진행 상태일 때 주문을 성공 처리할 수 있다`() {
         // given
-        val payment = Payment.create(1L, POINT, BigDecimal("1"), REQUESTED)
+        val payment = Payment.create(1L, POINT, BigDecimal("1"), PROCESSING)
 
         // when
         payment.success()
@@ -69,9 +70,9 @@ class PaymentTest {
     }
 
     @Test
-    fun `결제 요청 상태일 때 주문을 실패 처리할 수 있다`() {
+    fun `결제 진행 상태일 때 주문을 실패 처리할 수 있다`() {
         // given
-        val payment = Payment.create(1L, POINT, BigDecimal("1"), REQUESTED)
+        val payment = Payment.create(1L, POINT, BigDecimal("1"), PROCESSING)
 
         // when
         payment.failure("failReason")

--- a/apps/commerce-api/src/test/kotlin/com/loopers/infrastructure/pg/PgGatewayTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/infrastructure/pg/PgGatewayTest.kt
@@ -1,0 +1,157 @@
+package com.loopers.infrastructure.pg
+
+import com.loopers.domain.payment.type.TransactionStatus
+import com.loopers.infrastructure.pg.fixture.PgFixtures
+import com.loopers.interfaces.api.ApiResponse
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.time.Duration
+
+@SpringBootTest
+class PgGatewayTest @Autowired constructor(
+    private val gateway: PgGateway,
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    @MockitoBean private val pgClient: PgClient,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        circuitBreakerRegistry.allCircuitBreakers.forEach { it.reset() }
+        reset(pgClient)
+    }
+
+    @Nested
+    @DisplayName("재시도/에러 처리")
+    inner class RetryAndErrors {
+
+        @Test
+        fun `400대 에러이면 BadRequest를 반환하고 재시도하지 않는다`() {
+            val (userId, body) = PgFixtures.paymentRequestDto()
+            given(pgClient.payment(userId, body)).willThrow(PgFixtures.feign400())
+
+            val result = gateway.payment(userId, body)
+
+            assertThat(result).isInstanceOf(PgGateway.Result.BadRequest::class.java)
+            verify(pgClient, times(1)).payment(userId, body)
+        }
+
+        @Test
+        fun `500대 에러가 2번 후 성공하면 Ok를 반환한다`() {
+            val (userId, body) = PgFixtures.paymentRequestDto()
+            val ok = ApiResponse.success(
+                PgDto.TransactionResponse("TRANSACTION_KEY", TransactionStatus.SUCCESS, null),
+            )
+            given(pgClient.payment(userId, body))
+                .willThrow(PgFixtures.feign500())
+                .willThrow(PgFixtures.retryable())
+                .willReturn(ok)
+
+            val result = gateway.payment(userId, body)
+
+            assertThat(result).isInstanceOf(PgGateway.Result.Ok::class.java)
+            assertThat((result as PgGateway.Result.Ok).transactionKey).isEqualTo("TRANSACTION_KEY")
+            verify(pgClient, times(3)).payment(userId, body)
+        }
+
+        @Test
+        fun `타임아웃이 반복되면 최종적으로 Retryable을 반환한다`() {
+            val (userId, body) = PgFixtures.paymentRequestDto()
+            given(pgClient.payment(userId, body)).willAnswer { throw PgFixtures.retryable() }
+
+            val result = gateway.payment(userId, body)
+
+            assertThat(result).isInstanceOf(PgGateway.Result.Retryable::class.java)
+            verify(pgClient, times(3)).payment(userId, body)
+        }
+
+        @Test
+        fun `외부 장애가 발생해도 예외 대신 Result를 반환한다`() {
+            val (userId, body) = PgFixtures.paymentRequestDto()
+            given(pgClient.payment(userId, body)).willThrow(PgFixtures.feign500())
+
+            val result = gateway.payment(userId, body)
+
+            assertThat(result).isInstanceOf(PgGateway.Result.Retryable::class.java)
+        }
+
+        @Test
+        fun `재시도 모두 실패하면 Retryable을 반환한다`() {
+            val (userId, body) = PgFixtures.paymentRequestDto()
+            given(pgClient.payment(userId, body))
+                .willThrow(PgFixtures.retryable())
+                .willThrow(PgFixtures.feign500())
+                .willThrow(PgFixtures.retryable())
+
+            val result = gateway.payment(userId, body)
+
+            assertThat(result).isInstanceOf(PgGateway.Result.Retryable::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("서킷브레이커")
+    inner class CircuitBreakerBehavior {
+
+        @Test
+        fun `OPEN 상태라면 즉시 Retryable fallback이 발생한다`() {
+            val (userId, body) = PgFixtures.paymentRequestDto()
+            val circuitBreaker = circuitBreakerRegistry.circuitBreaker("pg")
+            circuitBreaker.transitionToOpenState()
+
+            val start = System.nanoTime()
+            val result = gateway.payment(userId, body)
+            val tookMs = Duration.ofNanos(System.nanoTime() - start).toMillis()
+
+            assertThat(result).isInstanceOf(PgGateway.Result.Retryable::class.java)
+            assertThat(tookMs).isLessThan(25)
+            verifyNoInteractions(pgClient)
+        }
+
+        @Test
+        fun `HALF_OPEN 상태에서 성공이 허용횟수만큼 이어지면 CLOSED로 전환된다`() {
+            val (userId, body) = PgFixtures.paymentRequestDto()
+            val circuitBreaker = circuitBreakerRegistry.circuitBreaker("pg")
+            circuitBreaker.transitionToOpenState()
+            circuitBreaker.transitionToHalfOpenState()
+
+            given(pgClient.payment(userId, body)).willReturn(
+                ApiResponse.success(PgDto.TransactionResponse("TX", TransactionStatus.SUCCESS, null)),
+            )
+
+            repeat(circuitBreaker.circuitBreakerConfig.permittedNumberOfCallsInHalfOpenState) {
+                gateway.payment(userId, body)
+            }
+
+            assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.CLOSED)
+        }
+
+        @Test
+        fun `HALF_OPEN 상태에서 실패가 발생하면 다시 OPEN으로 전환된다`() {
+            val (userId, body) = PgFixtures.paymentRequestDto()
+            val circuitBreaker = circuitBreakerRegistry.circuitBreaker("pg")
+            circuitBreaker.transitionToOpenState()
+            circuitBreaker.transitionToHalfOpenState()
+
+            given(pgClient.payment(userId, body)).willThrow(PgFixtures.feign500())
+
+            repeat(circuitBreaker.circuitBreakerConfig.permittedNumberOfCallsInHalfOpenState) {
+                gateway.payment(userId, body)
+            }
+
+            assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.OPEN)
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/infrastructure/pg/fixture/PgFixtures.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/infrastructure/pg/fixture/PgFixtures.kt
@@ -1,0 +1,39 @@
+package com.loopers.infrastructure.pg.fixture
+
+import com.loopers.domain.payment.type.CardType
+import com.loopers.infrastructure.pg.PgDto
+import feign.FeignException
+import feign.Request
+import feign.RequestTemplate
+import feign.RetryableException
+import java.nio.charset.StandardCharsets
+
+object PgFixtures {
+    fun paymentRequestDto(userId: Long = 1L) =
+        PgDto.PaymentRequest(
+            orderId = "LOOPERS-1",
+            cardType = CardType.KB,
+            cardNo = "1111-2222-3333-4444",
+            amount = 1000L,
+            callbackUrl = "http://localhost:8080/api/v1/payments/webhook",
+        ).also { it.validate() }.let { userId to it }
+
+    fun feignRequest(): Request =
+        Request.create(
+            Request.HttpMethod.POST,
+            "/api/v1/payments",
+            mapOf(),
+            ByteArray(0),
+            StandardCharsets.UTF_8,
+            RequestTemplate(),
+        )
+
+    fun feign400(): FeignException =
+        FeignException.BadRequest("400", feignRequest(), null, emptyMap())
+
+    fun feign500(): FeignException =
+        FeignException.InternalServerError("500", feignRequest(), null, emptyMap())
+
+    fun retryable(): RetryableException =
+        RetryableException(0, "io timeout", Request.HttpMethod.POST, 0L, feignRequest())
+}


### PR DESCRIPTION
## 📌 Summary
1. 서킷브레이커 및 레질리언스 설정 [dd6ffb0]
2. 상태 api를 통한 스케줄러 처리 [c9b59fc]

## 💬 Review Points
1. 스케줄러로 PG사 상태 API를 호출해서 상태 관련 정합성 처리를 진행하려고 하는데 특정 데이터가 오랜 기간동안 PENDING상태인 경우에는 어떻게 처리하는게 좋을까요? 그런 경우에는 보통 해당 PG사에 연락하여 진행상황을 물어보고 수동처리 하는게 맞을까요?

2. 사용자 결제 API에는 서킷브레이커를 적용하는 게 맞을 것 같은데, 백그라운드 스케줄러에는 같은 전략을 써야 할까요?

3. 시간이 부족해서 스케줄러를 돌릴 때 PENDING상태를 전부 불러오게끔 했는데, 개선한다면 결제 시 임시 테이블에 펜딩상태의 결제 정보를 넣어두고 실패나 성공 시 임시 테이블에서 해당 데이터를 제거하여 임시 테이블에 존재하는 데이터에 대해서만 스케줄러 대상이 되게끔 하는 방법은 어떻게 생각하시나요?

4. 스케줄러는 이미 실패,중단된 결제를 보정하기 위한 건데, 만약 서킷브레이커가 열려서 계속 호출을 차단하면, 오히려 보정하기 위한 로직이 무력화되지 않을까요?

5. PG API 호출 실패 시 Retry 정책을 쓰면, 동일 결제건에 대해 중복 결제 요청이 발생할 가능성이 있는데,
Retry를 어디까지 허용하고, 어떤 기준에서 멱등성 키를 활용해야 안전할까요?

## ✅ Checklist
- [ ]  PG 연동 API는 RestTemplate 혹은 FeignClient 로 외부 시스템을 호출한다.
- [ ]  응답 지연에 대해 타임아웃을 설정하고, 실패 시 적절한 예외 처리 로직을 구현한다.
- [ ]  결제 요청에 대한 실패 응답에 대해 적절한 시스템 연동을 진행한다.
- [ ]  콜백 방식 + **결제 상태 확인 API**를 활용해 적절하게 시스템과 결제정보를 연동한다.

### **🛡 Resilience 설계**

- [ ]  서킷 브레이커 혹은 재시도 정책을 적용하여 장애 확산을 방지한다.
- [ ]  외부 시스템 장애 시에도 내부 시스템은 **정상적으로 응답**하도록 보호한다.
- [ ]  콜백이 오지 않더라도, 일정 주기 혹은 수동 API 호출로 상태를 복구할 수 있다.
- [ ]  PG 에 대한 요청이 타임아웃에 의해 실패되더라도 해당 결제건에 대한 정보를 확인하여 정상적으로 시스템에 반영한다.